### PR TITLE
feat: 로그인 일반/소셜 구분 필드 추가

### DIFF
--- a/src/main/java/com/smile/mypark/domain/user/dto/request/LoginRequestDTO.java
+++ b/src/main/java/com/smile/mypark/domain/user/dto/request/LoginRequestDTO.java
@@ -11,6 +11,11 @@ public class LoginRequestDTO {
 	@NotBlank(message = "아이디는 필수입니다.")
 	private String uId;
 
+	@JsonProperty("password")
 	@NotBlank(message = "비밀번호는 필수입니다.")
 	private String password;
+
+	@JsonProperty("kind")
+	@NotBlank(message = "로그인 타입 필수입니다.")
+	private String kind;
 }

--- a/src/main/java/com/smile/mypark/domain/user/entity/User.java
+++ b/src/main/java/com/smile/mypark/domain/user/entity/User.java
@@ -54,7 +54,7 @@ public class User {
 	@Column(name = "isAgreeAlert")
 	private Boolean isAgreeAlert;
 
-	@Column(name = "u_idx")
+	@Column(name = "u_idx", unique = true)
 	private Long uIdx;
 
 	@Column(name = "u_regdate")
@@ -65,18 +65,18 @@ public class User {
 
 	@Builder
 	public User(String uId,
-				String password,
-				String nickname,
-				String kind,
-				Integer height,
-				Integer weight,
-				Integer age,
-				Integer gender,
-				Boolean isAgreePos,
-				Boolean isAgreeAlert,
-				Long uIdx,
-				LocalDateTime regDate,
-				LocalDateTime lastDate) {
+		String password,
+		String nickname,
+		String kind,
+		Integer height,
+		Integer weight,
+		Integer age,
+		Integer gender,
+		Boolean isAgreePos,
+		Boolean isAgreeAlert,
+		Long uIdx,
+		LocalDateTime regDate,
+		LocalDateTime lastDate) {
 		this.uId = uId;
 		this.password = password;
 		this.nickname = nickname;

--- a/src/main/java/com/smile/mypark/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/smile/mypark/domain/user/repository/UserRepository.java
@@ -14,4 +14,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByIdx(Long idx);
 
 	boolean existsByuId(String uId);
+
+	boolean existsByuIdx(Long uIdx);
 }

--- a/src/main/java/com/smile/mypark/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/smile/mypark/domain/user/service/UserServiceImpl.java
@@ -62,8 +62,14 @@ public class UserServiceImpl implements UserService {
 		User user = userRepository.findByuId(request.getUId())
 			.orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 
-		if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-			throw new GeneralException(ErrorStatus._INVALID_PASSWORD);
+		if (request.getKind().equals("normal")) {
+			if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+				throw new GeneralException(ErrorStatus._INVALID_PASSWORD);
+			}
+		} else {
+			if (!request.getPassword().equals(String.valueOf(user.getUIdx()))) {
+				throw new GeneralException(ErrorStatus._USER_SERVICE_NUMBER_INVALID);
+			}
 		}
 
 		TokenDTO tokenDTO = jwtUtil.generateTokens(String.valueOf(user.getUIdx()));

--- a/src/main/java/com/smile/mypark/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/smile/mypark/domain/user/service/UserServiceImpl.java
@@ -38,6 +38,12 @@ public class UserServiceImpl implements UserService {
 
 		String encodedPassword = passwordEncoder.encode(request.getPassword());
 
+		if (request.getUIdx() != null) {
+			if (userRepository.existsByuIdx(request.getUIdx())) {
+				throw new GeneralException(ErrorStatus._USER_SERVICE_NUMBER_DUPLICATE);
+			}
+		}
+
 		User user = User.builder()
 			.uId(request.getUId())
 			.password(encodedPassword)

--- a/src/main/java/com/smile/mypark/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/smile/mypark/global/apipayload/code/status/ErrorStatus.java
@@ -20,6 +20,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	_INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "USER4001", "비밀번호가 일치하지 않습니다."),
 	_USER_ID_DUPLICATE(HttpStatus.CONFLICT, "USER4002", "이미 존재하는 아이디입니다."),
 	_USER_SERVICE_NUMBER_INVALID(HttpStatus.NOT_FOUND, "USER4003", "일치하는 회원번호가 없습니다."),
+	_USER_SERVICE_NUMBER_DUPLICATE(HttpStatus.CONFLICT, "USER4004", "이미 등록된 회원번호입니다."),
 
 	_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH4000", "인증되지 않은 사용자입니다. 로그인 후 다시 시도해주세요."),
 

--- a/src/main/java/com/smile/mypark/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/smile/mypark/global/apipayload/code/status/ErrorStatus.java
@@ -19,6 +19,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4000", "사용자를 찾을 수 없습니다."),
 	_INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "USER4001", "비밀번호가 일치하지 않습니다."),
 	_USER_ID_DUPLICATE(HttpStatus.CONFLICT, "USER4002", "이미 존재하는 아이디입니다."),
+	_USER_SERVICE_NUMBER_INVALID(HttpStatus.NOT_FOUND, "USER4003", "일치하는 회원번호가 없습니다."),
 
 	_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH4000", "인증되지 않은 사용자입니다. 로그인 후 다시 시도해주세요."),
 


### PR DESCRIPTION
## 작업 내용 (Content)
- 일반 로그인과 소셜로그인 구분을 위한 로그인 타입(kind) 필드를 DTO 추가
- 일반 로그인(kind=normal)인 경우 비밀번호를 검증하고 소셜 로그인(kind=kakao)인 경우 시리얼 넘버로 구분한다.

## 기타 사항 (Etc)
- 회원가입 시 소셜 연동 ID(u_idx) 필드에 unique 옵션을 걸고, 중복을 체크 로직 추가